### PR TITLE
Fetch Tautulli straight from git master and add python-pip from entware

### DIFF
--- a/wdpk/tautulli/apkg.rc
+++ b/wdpk/tautulli/apkg.rc
@@ -1,5 +1,5 @@
 Package:	tautulli
-Version:	2.1.18
+Version:	2.1.18b
 Packager:	TFL
 Email:
 Homepage:	https://tautulli.com

--- a/wdpk/tautulli/apkg.rc
+++ b/wdpk/tautulli/apkg.rc
@@ -8,7 +8,7 @@ Icon:	        tautulli.png
 AddonShowName:	Tautulli
 AddonIndexPage:	index.html
 AddonUsedPort:	
-InstDepend:     
+InstDepend:     entware
 InstConflict:
 StartDepend:    entware
 StartConflict:

--- a/wdpk/tautulli/before_apkg.sh
+++ b/wdpk/tautulli/before_apkg.sh
@@ -3,8 +3,3 @@
 [ -f /tmp/debug_apkg ] && echo "APKG_DEBUG: $0 $@" >> /tmp/debug_apkg
 
 # DO NOT REMOVE
-# I don't know if it's required for backward compatibility
-# I don't have time to figure it out
-APKG_MODULE="tautulli"
-
-APKG_PATH=""

--- a/wdpk/tautulli/bootscript
+++ b/wdpk/tautulli/bootscript
@@ -34,9 +34,11 @@ DNAME="Tautulli"
 # Others
 PKG_DIR="/shares/Volume_1/Nas_Prog/${PACKAGE}"
 INSTALL_DIR="${PKG_DIR}/${DNAME}"
+DATA_DIR="${PKG_DIR}/data"
 PYTHON_DIR="/opt/bin"
 PATH="${INSTALL_DIR}/bin:${INSTALL_DIR}/env/bin:/opt/bin:/opt/sbin:/usr/local/bin:/bin:/usr/bin"
 RUNAS="tautulli"
+PORT=8282
 PYTHON="${PYTHON_DIR}/python2.7"
 PLEXPY="${INSTALL_DIR}/PlexPy.py"
 CFG_FILE="${PKG_DIR}/config.ini"
@@ -47,10 +49,13 @@ LOG_FILE="${PKG_DIR}/logs/tautulli.log"
 start_daemon ()
 {
     if [ 1 ]; then
-        PATH=${PATH} ${PYTHON} ${PLEXPY} --datadir ${INSTALL_DIR} --daemon --pidfile ${PID_FILE} --config ${CFG_FILE} --nolaunch
+        PATH=${PATH} ${PYTHON} ${PLEXPY} --port ${PORT} \
+		                         --datadir ${DATA_DIR} \
+	                                 --daemon --pidfile ${PID_FILE} \
+	                                 --config ${CFG_FILE} --nolaunch
     else
-        # TODO: create user in init.sh
-        su ${RUNAS} -c "PATH=${PATH} ${PYTHON} ${PLEXPY} --daemon --pidfile ${PID_FILE} --config ${CFG_FILE}" --nolaunch
+	# TODO: create user in init.sh
+        echo "TODO"
     fi
 }
 

--- a/wdpk/tautulli/bootscript
+++ b/wdpk/tautulli/bootscript
@@ -1,0 +1,116 @@
+#!/bin/sh
+# inspired by synology start-stop script 
+
+# Output of PlexPy.py --help
+#
+# usage: PlexPy.py [-h] [-v] [-q] [-d] [-p PORT] [--dev] [--datadir DATADIR]
+#                  [--config CONFIG] [--nolaunch] [--pidfile PIDFILE] [--nofork]
+#
+# A Python based monitoring and tracking tool for Plex Media Server.
+#
+# optional arguments:
+#   -h, --help            show this help message and exit
+#   -v, --verbose         Increase console logging verbosity
+#   -q, --quiet           Turn off console logging
+#   -d, --daemon          Run as a daemon
+#   -p PORT, --port PORT  Force Tautulli to run on a specified port
+#   --dev                 Start Tautulli in the development environment
+#   --datadir DATADIR     Specify a directory where to store your data files
+#   --config CONFIG       Specify a config file to use
+#   --nolaunch            Prevent browser from launching on startup
+#   --pidfile PIDFILE     Create a pid file (only relevant when running as a
+#                         daemon)
+#   --nofork              Start Tautulli as a service, do not fork when
+#                         restarting
+
+
+# Fix for language issues
+export LANG=en_US.UTF8
+
+# Package
+PACKAGE="tautulli"
+DNAME="Tautulli"
+
+# Others
+PKG_DIR="/shares/Volume_1/Nas_Prog/${PACKAGE}"
+INSTALL_DIR="${PKG_DIR}/${DNAME}"
+PYTHON_DIR="/opt/bin"
+PATH="${INSTALL_DIR}/bin:${INSTALL_DIR}/env/bin:/opt/bin:/opt/sbin:/usr/local/bin:/bin:/usr/bin"
+RUNAS="tautulli"
+PYTHON="${PYTHON_DIR}/python2.7"
+PLEXPY="${INSTALL_DIR}/PlexPy.py"
+CFG_FILE="${PKG_DIR}/config.ini"
+PID_FILE="/var/run/tautulli.pid"
+LOG_FILE="${PKG_DIR}/logs/tautulli.log"
+
+
+start_daemon ()
+{
+    if [ 1 ]; then
+        PATH=${PATH} ${PYTHON} ${PLEXPY} --datadir ${INSTALL_DIR} --daemon --pidfile ${PID_FILE} --config ${CFG_FILE} --nolaunch
+    else
+        # TODO: create user in init.sh
+        su ${RUNAS} -c "PATH=${PATH} ${PYTHON} ${PLEXPY} --daemon --pidfile ${PID_FILE} --config ${CFG_FILE}" --nolaunch
+    fi
+}
+
+stop_daemon()
+{
+    kill $(cat ${PID_FILE})
+    wait_for_status 1 20
+    rm -f ${PID_FILE}
+}
+
+daemon_status()
+{
+    if [ -f ${PID_FILE} ] && [ -d /proc/$(cat ${PID_FILE}) ]; then
+        return 0
+    fi
+    return 1
+}
+
+wait_for_status()
+{
+    counter=$2
+    while [ ${counter} -gt 0 ]; do
+                daemon_status
+        [ $? -eq $1 ] && break
+                counter=`expr $counter - 1`
+        sleep 1
+    done
+}
+
+case $1 in
+    start)
+        if daemon_status; then
+                        echo ${DNAME} is already running
+        else
+                        echo Starting ${DNAME} ...
+            start_daemon
+        fi
+        ;;
+    stop)
+        if daemon_status; then
+                        echo Stopping ${DNAME} ...
+            stop_daemon
+        else
+                        echo ${DNAME} is not running
+        fi
+        ;;
+    status)
+        if daemon_status; then
+                        echo ${DNAME} is running
+            exit 0
+        else
+                        echo ${DNAME} is not running
+            exit 1
+        fi
+        ;;
+    log)
+        echo ${LOG_FILE}
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+

--- a/wdpk/tautulli/clean.sh
+++ b/wdpk/tautulli/clean.sh
@@ -5,8 +5,8 @@
 APP=plexpy
 WEBPATH="/var/www/$APP"
 
-# remove bin
-# it just uses python
+# remove bootscript
+rm /opt/etc/init.d/S43Tautulli.sh
 
 # remove lib
 

--- a/wdpk/tautulli/init.sh
+++ b/wdpk/tautulli/init.sh
@@ -2,15 +2,16 @@
 
 [ -f /tmp/debug_apkg ] && echo "APKG_DEBUG: $0 $@" >> /tmp/debug_apkg
 
-path=$1
+APKG_PATH=$(readlink -f $1)
 log=/tmp/debug_apkg
 
-echo "INIT linking files from path: $path" >> $log
+echo "INIT linking files from path: ${APKG_PATH}" >> $log
 
-# create link to binary
+# add app to init.d
+ln -sf ${APKG_PATH}/bootscript /opt/etc/init.d/S43Tautulli.sh
 
 # create folder for the redirecting webpage
 WEBPATH="/var/www/tautulli/"
 mkdir -p $WEBPATH
-ln -sf $path/web/* $WEBPATH
+ln -sf ${APKG_PATH}/web/* $WEBPATH
 

--- a/wdpk/tautulli/install.sh
+++ b/wdpk/tautulli/install.sh
@@ -23,10 +23,12 @@ mv cacert.pem /etc/ssl/cert.pem
 
 # install pip to get pkg_resources module
 /opt/bin/opkg install python-light python-pip git git-http
+[ ! $? -eq 0 ] && exit 2
 
 # get the Tautulli source code
 cd ${APKG_PATH}
 /opt/bin/git clone https://github.com/Tautulli/Tautulli.git
+[ ! $? -eq 0 ] && exit 3
 
 # restore config
 if [ -f ${APKG_CONFIG_BACKUP} ]; then

--- a/wdpk/tautulli/install.sh
+++ b/wdpk/tautulli/install.sh
@@ -10,9 +10,9 @@ log=/tmp/debug_apkg
 APKG_MODULE="tautulli"
 APKG_PATH="${NAS_PROG}/${APKG_MODULE}"
 APKG_CONFIG="${APKG_PATH}/config.ini"
-APKG_CONFIG_BACKUP="/mnt/HD/HD_a2/.systemfile/{APKG_MODULE}.ini"
+APKG_CONFIG_BACKUP="/mnt/HD/HD_a2/.systemfile/${APKG_MODULE}.ini"
 DATA_DIR="${APKG_PATH}/data"
-DATA_DIR_BACKUP="/mnt/HD/HD_a2/.systemfile/{APKG_MODULE}_data"
+DATA_DIR_BACKUP="/mnt/HD/HD_a2/.systemfile/${APKG_MODULE}_data/"  # note the trailing slash
 
 # install all package scripts to the proper location
 cp -rf ${INSTALL_DIR} ${NAS_PROG}

--- a/wdpk/tautulli/install.sh
+++ b/wdpk/tautulli/install.sh
@@ -2,46 +2,37 @@
 
 [ -f /tmp/debug_apkg ] && echo "APKG_DEBUG: $0 $@" >> /tmp/debug_apkg
 
-path_src=$1
-path_dst=$2
+INSTALL_DIR=$1
+NAS_PROG=$2
 
 log=/tmp/debug_apkg
 
 APKG_MODULE="tautulli"
 APKG_PATH="${path_dst}/${APKG_MODULE}"
-APKG_CONFIG="${APKG_PATH}/${APKG_MODULE}.conf"
-APKG_BACKUP_CONFIG="/mnt/HD/HD_a2/.systemfile/{APKG_MODULE}.conf"
-
-# create backup of nzbget configuration
-cp -f ${APKG_CONFIG} ${APKG_BACKUP_CONFIG}
+APKG_CONFIG="${APKG_PATH}/config.ini"
+APKG_CONFIG_BACKUP="/mnt/HD/HD_a2/.systemfile/{APKG_MODULE}.ini"
+DATA_DIR="${APKG_PATH}/data"
+DATA_DIR_BACKUP="/mnt/HD/HD_a2/.systemfile/{APKG_MODULE}_data"
 
 # install all package scripts to the proper location
-cp -rf $path_src $path_dst
+cp -rf ${INSTALL_DIR} ${NAS_PROG}
 
 # setup secure downloads
 curl --remote-name --time-cond cacert.pem https://curl.haxx.se/ca/cacert.pem
 mv cacert.pem /etc/ssl/cert.pem
 
-# download the latest PlexPy package from github
-wget https://github.com/Tautulli/Tautulli/archive/master.zip -P "${APKG_PATH}" 2>&1 >> $log
-
-result=$?
-echo "Download ${APKG_MODULE} RC: $result" >> $log
-
-# unpack plexpy-master
-unzip "${APKG_PATH}/master.zip" -d "${APKG_PATH}" 2>&1 >> $log
-
-result=$?
-echo "Unpack RC: $result" >> $log
-
-# remove the archive
-rm "${APKG_PATH}/master.zip"
-
 # install pip to get pkg_resources module
-wget https://bootstrap.pypa.io/get-pip.py
-/opt/bin/opkg install python-light
-/opt/bin/python get-pip.py
-rm get-pip.py
+/opt/bin/opkg install python-light python-pip git git-http
 
-echo "Addon Tautulli (install.sh) done" >> $log
+# get the Tautulli source code
+/opt/bin/git clone https://github.com/Tautulli/Tautulli.git
+
+# restore config
+if [ -f ${APKG_CONFIG_BACKUP} ]; then
+  echo "Restore ${APKG_MODULE} config"
+  cp ${APKG_CONFIG_BACKUP} ${APKG_CONFIG}
+  cp -r ${DATA_DIR_BACKUP} ${DATA_DIR}
+fi
+
+echo "Addon ${APKG_MODULE} (install.sh) done" >> $log
 

--- a/wdpk/tautulli/install.sh
+++ b/wdpk/tautulli/install.sh
@@ -2,13 +2,13 @@
 
 [ -f /tmp/debug_apkg ] && echo "APKG_DEBUG: $0 $@" >> /tmp/debug_apkg
 
-INSTALL_DIR=$1
-NAS_PROG=$2
+INSTALL_DIR=$(readlink -f $1)
+NAS_PROG=$(readlink -f $2)
 
 log=/tmp/debug_apkg
 
 APKG_MODULE="tautulli"
-APKG_PATH="${path_dst}/${APKG_MODULE}"
+APKG_PATH="${NAS_PROG}/${APKG_MODULE}"
 APKG_CONFIG="${APKG_PATH}/config.ini"
 APKG_CONFIG_BACKUP="/mnt/HD/HD_a2/.systemfile/{APKG_MODULE}.ini"
 DATA_DIR="${APKG_PATH}/data"
@@ -25,6 +25,7 @@ mv cacert.pem /etc/ssl/cert.pem
 /opt/bin/opkg install python-light python-pip git git-http
 
 # get the Tautulli source code
+cd ${APKG_PATH}
 /opt/bin/git clone https://github.com/Tautulli/Tautulli.git
 
 # restore config

--- a/wdpk/tautulli/remove.sh
+++ b/wdpk/tautulli/remove.sh
@@ -7,10 +7,15 @@ APKG_PATH=$1
 # keep config
 APKG_MODULE="tautulli"
 APKG_CONFIG="${APKG_PATH}/config.ini"
-APKG_CONFIG_BACKUP="/mnt/HD/HD_a2/.systemfile/{APKG_MODULE}.ini"
+APKG_CONFIG_BACKUP="/mnt/HD/HD_a2/.systemfile/${APKG_MODULE}.ini"
 DATA_DIR="${APKG_PATH}/data"
-DATA_DIR_BACKUP="/mnt/HD/HD_a2/.systemfile/{APKG_MODULE}_data"
+DATA_DIR_BACKUP="/mnt/HD/HD_a2/.systemfile/${APKG_MODULE}_data"
 
+# remove old backups
+rm ${APKG_CONFIG_BACKUP}
+rm -rf ${DATA_DIR_BACKUP}
+
+# store new backup
 mv ${APKG_CONFIG} ${APKG_CONFIG_BACKUP}
 mv ${DATA_DIR} ${DATA_DIR_BACKUP}
 

--- a/wdpk/tautulli/remove.sh
+++ b/wdpk/tautulli/remove.sh
@@ -2,9 +2,19 @@
 
 [ -f /tmp/debug_apkg ] && echo "APKG_DEBUG: $0 $@" >> /tmp/debug_apkg
 
-path=$1
+APKG_PATH=$1
 
-rm -rf $path
+rm -rf ${APKG_PATH}
+
+# keep config
+APKG_MODULE="tautulli"
+APKG_CONFIG="${APKG_PATH}/config.ini"
+APKG_CONFIG_BACKUP="/mnt/HD/HD_a2/.systemfile/{APKG_MODULE}.ini"
+DATA_DIR="${APKG_PATH}/data"
+DATA_DIR_BACKUP="/mnt/HD/HD_a2/.systemfile/{APKG_MODULE}_data"
+
+cp ${APKG_CONFIG} ${APKG_CONFIG_BACKUP}
+cp -r ${DATA_DIR} ${DATA_DIR_BACKUP}
 
 # remove bin
 

--- a/wdpk/tautulli/remove.sh
+++ b/wdpk/tautulli/remove.sh
@@ -4,8 +4,6 @@
 
 APKG_PATH=$1
 
-rm -rf ${APKG_PATH}
-
 # keep config
 APKG_MODULE="tautulli"
 APKG_CONFIG="${APKG_PATH}/config.ini"
@@ -13,8 +11,11 @@ APKG_CONFIG_BACKUP="/mnt/HD/HD_a2/.systemfile/{APKG_MODULE}.ini"
 DATA_DIR="${APKG_PATH}/data"
 DATA_DIR_BACKUP="/mnt/HD/HD_a2/.systemfile/{APKG_MODULE}_data"
 
-cp ${APKG_CONFIG} ${APKG_CONFIG_BACKUP}
-cp -r ${DATA_DIR} ${DATA_DIR_BACKUP}
+mv ${APKG_CONFIG} ${APKG_CONFIG_BACKUP}
+mv ${DATA_DIR} ${DATA_DIR_BACKUP}
+
+# clean up
+rm -rf ${APKG_PATH}
 
 # remove bin
 

--- a/wdpk/tautulli/start.sh
+++ b/wdpk/tautulli/start.sh
@@ -7,5 +7,5 @@ echo "APKG_DEBUG: starting PlexPy on port 8282" >> /tmp/debug_apkg
 
 APPDIR=$1
 
-cd "${APPDIR}/Tautulli-master"
+cd "${APPDIR}/Tautulli"
 python ./PlexPy.py --port 8282 --daemon --pidfile /var/run/plexpy.pid

--- a/wdpk/tautulli/start.sh
+++ b/wdpk/tautulli/start.sh
@@ -5,7 +5,4 @@ export PATH=/opt/bin:/opt/sbin:$PATH
 
 echo "APKG_DEBUG: starting PlexPy on port 8282" >> /tmp/debug_apkg
 
-APPDIR=$1
-
-cd "${APPDIR}/Tautulli"
-python ./PlexPy.py --port 8282 --daemon --pidfile /var/run/plexpy.pid
+/opt/etc/init.d/S43Tautulli.sh start

--- a/wdpk/tautulli/stop.sh
+++ b/wdpk/tautulli/stop.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
 # stop daemon
+/opt/etc/init.d/S43Tautulli.sh stop
+
 kill `cat /var/run/plexpy.pid`


### PR DESCRIPTION
Installation was failing when fetching pip with get-pip.py.

- use entware python-pip package instead of get-pip
- added sanity checks during install
- restore db and config on install (only applies to installs after this version)
- add entware as installation dependency
- use git to fetch tautulli instead of downloading a package