### PR TITLE
Entware for ARMv5 (EX2, EX4 and MyCloud)

### DIFF
--- a/wdpk/entware/apkg.rc
+++ b/wdpk/entware/apkg.rc
@@ -5,7 +5,7 @@ Email:
 Homepage:	https://github.com/Entware/Entware
 Description:	Ultimate repo for embedded devices
 Icon:	        entware.png
-AddonShowName:	Entware-ng
+AddonShowName:	Entware
 AddonIndexPage:	
 AddonUsedPort:	
 InstDepend:

--- a/wdpk/entware/apkg.rc
+++ b/wdpk/entware/apkg.rc
@@ -1,5 +1,5 @@
 Package:	entware
-Version:	1.04
+Version:	1.05
 Packager:	TFL
 Email:
 Homepage:	https://github.com/Entware/Entware

--- a/wdpk/entware/install.sh
+++ b/wdpk/entware/install.sh
@@ -22,6 +22,8 @@ mount --bind ${OPT_ROOT} /opt 2>&1 | tee -a $LOG
 ARCH="$(uname -m)"
 if [ ${ARCH} = "x86_64" ]; then
     ENT_ARCH="x64"
+elif [ ${ARCH} = "armv5tel" ]; then
+    ENT_ARCH="armv5sf"
 else
     ENT_ARCH="armv7sf"
 fi

--- a/wdpk/entware/preinst.sh
+++ b/wdpk/entware/preinst.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-[ -f /tmp/debug_apkg ] && echo "APKG_DEBUG: $0 $@" >> /tmp/debug_apkg
+[[ -f /tmp/debug_apkg ]] && echo "APKG_DEBUG: $0 $@" >> /tmp/debug_apkg
 
 APKG_PATH=$1
 
+# invalidate old entware installation leftovers
+# restore them if necessary
+ENTWARE_ROOT=/shares/Volume_1/entware
+BACKUP=${ENTWARE_ROOT}.bak
+[[ -d ${ENTWARE_ROOT} ]] && mv ${ENTWARE_ROOT} ${BACKUP}

--- a/wdpk/entware/remove.sh
+++ b/wdpk/entware/remove.sh
@@ -7,8 +7,8 @@ path=$1
 # remove /opt from shell path
 rm -f /etc/profile
 
-# uncomment this to remove all your entware apps
-#rm -rf /shares/Volume_1/entware
+# comment this to prevent removing all your entware apps
+rm -rf /shares/Volume_1/entware
 
 # remove init.d startup hook
 


### PR DESCRIPTION
Fixes installation failures on EX2, EX4 and MyCloud platform. See https://github.com/WDCommunity/wdpksrc/issues/29
Also cleans up old remains from the old Entware branches.
A backup of your entware directory is available at entware.bak

I'm not sure if I should restore the root directory on install...