### PR TITLE
portainer updates to install.sh

### DIFF
--- a/wdpk/docker/install.sh
+++ b/wdpk/docker/install.sh
@@ -85,9 +85,9 @@ sleep 3
 # install portainer to manage docker, only if there is no container Portainer (running or not)
 docker ps -a | grep portainer
 if [ $? = 1 ]; then
-    docker run -d -p 9000:9000 --restart always \
+    docker run -d -p 9000:9000 --restart always --name portainer \
                -v /var/run/docker.sock:/var/run/docker.sock \
-               -v $(readlink -f ${APKG_PATH})/portainer:/data portainer/portainer
+               -v $(readlink -f ${APKG_PATH})/portainer:/data portainer/portainer-ce
 fi
 
 # install docker-compose


### PR DESCRIPTION
Include the container name explicitly at runtime, and move to CE (2.0) of Portainer.

See https://www.portainer.io/2020/08/portainer-ce-2-0-what-to-expect/ for specifics of Portainer changes, but relevant part: " ... we have been criticized for having closed source features as part of the open source project, and so by removing them Portainer CE reverts back to being 100% open source. "