### PR TITLE
Update docker support for OS5 for ARM WD NAS versions

### DIFF
--- a/wdpk/docker/apkg.rc
+++ b/wdpk/docker/apkg.rc
@@ -1,5 +1,5 @@
 Package:	docker
-Version:	19.03.8
+Version:	19.03.13
 Packager:	TFL
 Email:
 Homepage:	https://docker.com

--- a/wdpk/docker/install.sh
+++ b/wdpk/docker/install.sh
@@ -28,7 +28,7 @@ cd "${APKG_PATH}"
 if [ ${ARCH} != "x86_64" ]; then
 	# Update the "ARCH" to "armhf" so it matches the docker download site
 	# Versions above "19.03.8" do not have a working "dockerd" binary on WD EX4100
-    ARCH="armhf"
+	ARCH="armhf"
 	VERSION="19.03.8"
 fi
 

--- a/wdpk/docker/install.sh
+++ b/wdpk/docker/install.sh
@@ -6,7 +6,7 @@ path_src=$1
 NAS_PROG=$2
 
 # define docker version
-VERSION="19.03.8"
+VERSION="19.03.13"
 
 log=/tmp/debug_apkg
 
@@ -24,16 +24,16 @@ ARCH="$(uname -m)"
 
 # download docker binaries
 cd "${APKG_PATH}"
-TARBALL="docker-${VERSION}.tgz"
 
 if [ ${ARCH} != "x86_64" ]; then
-    ARCH="armel"
-    # JediNite provides custom docker packages for ARM
-    # They are based on docker-runc without seccomp, as the kernel doesn't support it
-    URL="https://github.com/JediNite/docker-ce-WDEX4100-binaries/releases/download/${VERSION}/${TARBALL}"
-else
-    URL="https://download.docker.com/linux/static/stable/${ARCH}/${TARBALL}"
+	# Update the "ARCH" to "armhf" so it matches the docker download site
+	# Versions above "19.03.8" do not have a working "dockerd" binary on WD EX4100
+    ARCH="armhf"
+	VERSION="19.03.8"
 fi
+
+TARBALL="docker-${VERSION}.tgz"
+URL="https://download.docker.com/linux/static/stable/${ARCH}/${TARBALL}"
 
 # download and extract the package
 curl -L "${URL}" | tar xz >> $log 2>&1
@@ -83,11 +83,11 @@ sleep 1
 sleep 3
 
 # install portainer to manage docker, only if there is no container Portainer (running or not)
-docker ps -a | grep portainer
+docker ps -a | grep portainer-ce
 if [ $? = 1 ]; then
     docker run -d -p 9000:9000 --restart always \
-               -v /var/run/docker.sock:/var/run/docker.sock \
-               -v $(readlink -f ${APKG_PATH})/portainer:/data portainer/portainer
+               --name portainer-ce -v /var/run/docker.sock:/var/run/docker.sock \
+               -v $(readlink -f ${APKG_PATH})/portainer:/data portainer/portainer-ce
 fi
 
 # proof that everything works

--- a/wdpk/docker/update_portainer.sh
+++ b/wdpk/docker/update_portainer.sh
@@ -1,17 +1,17 @@
 !#/bin/sh
 
 # Define APKG_PATH
-APKG_PATH="/mnt/HD/HD_a2/Nas_Prog/docker"
+APKG_PATH="/shares/Volume_1/Nas_Prog"
 
 # Stop and remove the old container
-docker stop portainer
-docker rm portainer
+docker stop portainer-ce
+docker rm portainer-ce
 
 # Download the latest container build from dockerhub
-docker pull portainer/portainer
+docker pull portainer/portainer-ce
 
 # Instantiate the new container
-docker run -d -p 9000:9000 --restart always --name portainer -v /var/run/docker.sock:/var/run/docker.sock -v $(readlink -f ${APKG_PATH})/portainer:/data portainer/portainer
+docker run -d -p 9000:9000 --restart always --name portainer-ce -v /var/run/docker.sock:/var/run/docker.sock -v $(readlink -f ${APKG_PATH})/portainer:/data portainer/portainer-ce
 
 # Display listing of running containers
 docker ps -a


### PR DESCRIPTION
This pull request expands on @irctrakz's pull request raised in https://github.com/WDCommunity/wdpksrc/pull/66 by simplifying the logic used to determine the URL for downloading docker since the official packages can now be used on ARM NAS. 

The maximum version that works on an EX4100 is 19.03.8 but on x86_64 based NAS is 19.03.13, so changed some of the logic in the install.sh script to change the version installed if on an ARM NAS.

The references to portainer have been updated to portainer-ce where necessary.