### PR TITLE
NZBget: fix config restore on upgrade

### DIFF
--- a/wdpk/nzbget/apkg.rc
+++ b/wdpk/nzbget/apkg.rc
@@ -1,5 +1,5 @@
 Package:	nzbget
-Version:	20.11.17
+Version:	20.11.29
 Packager:	TFL
 Email:
 Homepage:	https://nzbget.net

--- a/wdpk/nzbget/init.sh
+++ b/wdpk/nzbget/init.sh
@@ -2,7 +2,7 @@
 
 [ -f /tmp/debug_apkg ] && echo "APKG_DEBUG: $0 $@" >> /tmp/debug_apkg
 
-path=$1
+path=$(readlink -f $1)
 log=/tmp/nzbget.log
 
 echo "INIT linking files from path: $path" >> $log

--- a/wdpk/nzbget/install.sh
+++ b/wdpk/nzbget/install.sh
@@ -10,7 +10,8 @@ log=/tmp/debug_apkg
 APKG_MODULE="nzbget"
 APKG_PATH="${path_dst}/${APKG_MODULE}"
 APKG_CONFIG="${APKG_PATH}/nzbget.conf"
-APKG_BACKUP_CONFIG="/mnt/HD/HD_a2/.systemfile/nzbget.conf"
+APKG_BACKUP_DIR="${path_dst}/${APKG_MODULE}_backup"
+APKG_BACKUP_CONFIG="${APKG_BACKUP_DIR}/nzbget.conf"
 
 # install all package scripts to the proper location
 mv $path_src $path_dst
@@ -41,11 +42,11 @@ echo "Install RC: $result" >> $log
 rm ${path_dst}/nzbget-latest-bin-linux.run
 
 # restore previous config
-if [ -f /mnt/HD/HD_a2/.systemfile/nzbget.conf ]
+if [ -d ${APKG_BACKUP_DIR} ]
 then
-   echo "Addon NZBget (install.sh) restore configs" >> $log
+   echo "Addon ${APKG_MODULE} (install.sh) restore configs" >> $log
    cp ${APKG_BACKUP_CONFIG} ${APKG_CONFIG}
-   rm -f ${APKG_BACKUP_CONFIG}
+   rm -rf ${APKG_BACKUP_DIR}
 else
    # setup default MainDir
    sed -i "s|^MainDir=.*|MainDir=/shares/Public/nzbget|" ${APKG_CONFIG}

--- a/wdpk/nzbget/preinst.sh
+++ b/wdpk/nzbget/preinst.sh
@@ -9,8 +9,8 @@ APKG_BACKUP_PATH=${APKG_PATH}/../${APKG_MODULE}_backup
 
 
 # backup config files and user settings
-if [ ! -d ${APKG_BACKUP_PATH}] ; then
+if [ ! -d ${APKG_BACKUP_PATH} ] ; then
     # copy config to /tmp
     mkdir -p ${APKG_BACKUP_PATH}
-    mv -f $APKG_PATH/config ${APKG_BACKUP_PATH}
+    mv -f $APKG_PATH/nzbget.conf ${APKG_BACKUP_PATH}
 fi

--- a/wdpk/nzbget/start.sh
+++ b/wdpk/nzbget/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ ! -f /usr/bin/nzbget ] echo "nzbget not found" >> /tmp/debug_apkg
+[[ ! -f /usr/bin/nzbget ]] && echo "nzbget not found" >> /tmp/debug_apkg
 
-[ -f /tmp/debug_apkg ] echo "APKG_DEBUG: starting NZBget in Daemon mode" >> /tmp/debug_apkg
+[[ -f /tmp/debug_apkg ]] && echo "APKG_DEBUG: starting NZBget in Daemon mode" >> /tmp/debug_apkg
 nzbget -D


### PR DESCRIPTION
upgrade `preinst` script looks at the wrong files and has invalid syntax