### PR TITLE
Update docker and docker-compose version

### DIFF
--- a/wdpk/docker/apkg.rc
+++ b/wdpk/docker/apkg.rc
@@ -1,5 +1,5 @@
 Package:	docker
-Version:	20.10.2
+Version:	20.10.5
 Packager:	TFL
 Email:
 Homepage:	https://docker.com

--- a/wdpk/docker/install.sh
+++ b/wdpk/docker/install.sh
@@ -6,7 +6,7 @@ path_src=$1
 NAS_PROG=$2
 
 # define docker version
-VERSION="20.10.2"
+VERSION="20.10.5"
 
 log=/tmp/debug_apkg
 
@@ -92,7 +92,7 @@ fi
 
 # install docker-compose
 dc="${APKG_PATH}/docker/docker-compose"
-curl -L https://github.com/docker/compose/releases/download/1.27.4/run.sh -o $dc
+curl -L https://github.com/docker/compose/releases/download/1.28.5/run.sh -o $dc
 chmod +x $dc
 
 # proof that everything works


### PR DESCRIPTION
Latest and greatest!

Docker version: 20.10.5
Docker-compose version: 1.28.5

Testing performed:
- Deployed this to a PR4100 to and the `docker --version` worked.