### PR TITLE
Add CloudSmith

### DIFF
--- a/.github/workflows/wdpk.yml
+++ b/.github/workflows/wdpk.yml
@@ -12,12 +12,18 @@ name: WD MyCloud package CI
 on:
   push:
     branches: [ master ]
+    paths:
+      - wdpk/**
   pull_request:
+    types: [ synchronize ]
     branches: [ master ]
+    paths:
+      - wdpk/**
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+  # This workflow should get 3 jobs: build, test and publish
+
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -46,6 +52,8 @@ jobs:
         - model: PR2100
           platform: MyCloudPR2100
 
+    environment: staging
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -65,29 +73,23 @@ jobs:
           echo "Packages: ${pkgs}"
           echo "PACKAGE=${pkgs}" >> $GITHUB_ENV
 
-      # TODO: use matrix instead
-      - name: Get platforms
-        id: platforms
-        run: |
-          PLATFORMS="WDMyCloudEX4100-EX4100 WDMyCloudDL4100-DL4100 WDMyCloudEX2100-EX2100 WDMyCloudDL2100-DL2100 WDMyCloudMirror-MirrorG2 MyCloudEX2Ultra-EX2Ultra MyCloudPR4100-PR4100 MyCloudPR2100-PR2100"
-          echo "Use act ${use_act}"
-          echo "PLATFORMS=${PLATFORMS}" >> $GITHUB_ENV
-
       - name: Make APKG packages for selected platforms
         id: make_apkg
         env:
           PLATFORM: ${{ matrix.platform }}
           MODEL: ${{ matrix.model }}
         run: |
-          pkg=$(echo ${PACKAGE} | cut -d' ' -f1)
+          pkg=$(echo ${PACKAGE:-docker} | cut -d' ' -f1)
           echo ::set-output name=pkg::"$pkg"
           cd wdpk/${pkg}
           DATE="$(date +"%m%d%Y")"
           CWD="$(pwd)"
           VERSION="$(awk '/Version/{print $NF}' apkg.rc)"
-          echo ::set-output name=version::"$VERSION"
+          echo ::set-output name=version::"${VERSION}"
           NAME="$(awk '/AddonShowName/{print $NF}' apkg.rc)"
-          echo ::set-output name=name::"$NAME"
+          echo ::set-output name=name::"${NAME}"
+          DESCRIPTION="$(awk '/Description/{print $NF}' apkg.rc)"
+          echo ::set-output name=description::"${DESCRIPTION}"
 
           echo "Building ${pkg} version ${VERSION}"
           echo "$(ls -l ../..)"
@@ -106,16 +108,18 @@ jobs:
           name: ${{ steps.make_apkg.outputs.pkg }}_${{ steps.make_apkg.outputs.version }}_OS5
           path: wdpk/*_*_*.bin
 
-      - name: Upload binary packages to Bintray when a tag is included
-        uses: masofcon/upload-to-bintray-github-action@master
+      - name: Publish packages to CloudSmith
+        id: push
+        uses: cloudsmith-io/action@master
         with:
-          source_path: ./wdpk/${{steps.make_apkg.outputs.pkg}}_${{steps.make_apkg.outputs.version}}_*.bin
-          api_user: tfl
-          api_key: ${{ secrets.BINTRAY_API_KEY }} # An API key can be obtained from the user profile page.
-          repository: wdpksrc
-          package: ${{ steps.make_apkg.outputs.name }}
-          version: ${{ steps.make_apkg.outputs.version }}
-          upload_path: ${{ steps.make_apkg.outputs.pkg }}/OS5
-          publish: 1
-          override: 0
-        if: env.HEAD_TAG != ''
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: 'push'
+          format: 'raw'
+          owner: 'wd-community'        # Your Cloudsmith account name or org name (namespace)
+          repo: ${{matrix.model}}      # Your Cloudsmith Repository name (slug)
+          file: ./wdpk/${{steps.make_apkg.outputs.pkg}}_${{steps.make_apkg.outputs.version}}_${{matrix.model}}.bin     # Name of file
+          name: ${{steps.make_apkg.outputs.pkg}}              # Name for Raw package
+          summary: ${{ github.sha }}                          # Optional Summary for Raw Package
+          description: ${{steps.make_apkg.outputs.description}}   # Optional description for Raw package
+          version: ${{steps.make_apkg.outputs.version}}
+          republish: "true"

--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 
 source .env
 
-act --secret-file .env -e gh.json
+act --secret-file .env  # -e gh.json

--- a/wdpk/docker/apkg.rc
+++ b/wdpk/docker/apkg.rc
@@ -1,5 +1,5 @@
 Package:	docker
-Version:	20.10.5
+Version:	21.04.06
 Packager:	TFL
 Email:
 Homepage:	https://docker.com


### PR DESCRIPTION
As Bintray is shutting down, this seems like an easy drop-in replacement.

Specs for hosting solution:
- not on my own hardware as I can't guarantee the uptime
- should have CI/CD integration with Github actions
- open source friendly.. should have a free plan
- I want to see some download statistics

e.g. EX2Ultra packages should end up here:
https://cloudsmith.io/~wd-community/repos/EX2Ultra/packages/