### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Currently, these custom WD targets are available in this `SynoCommunity fork`_
 
 Some installer script changes might be necessary.
 
+**Note**: 
+  1. If mksapkg is not found, create a link for mksapkg with source file as mksapkg-OS5 or mksapkg-OS3 as needed.
+  2. If make command doesnt work, use build.sh
 
 # Hosting
 


### PR DESCRIPTION
bin files for Duplicati didnt work in mycloudpr4100. It appears bin files for Duplicati were compiled for OS-3. Building the package is failing as mksapkg is not found. All that has to be done is create a link for mksapkg-OS5 to mksapkg and run build.sh