### PR TITLE
fixed syncthing running as root error and permission issues on share

### DIFF
--- a/wdpk/syncthing/start.sh
+++ b/wdpk/syncthing/start.sh
@@ -8,9 +8,8 @@ APKG_PATH=$1
 # get first match for IP address
 ADDRESS=$(sed -n '/ip/ {s/.*<ip>\(\S*\)<\/ip>/\1/p;q}' /etc/NAS_CFG/config.xml )
 
-# disable creation of default folder
-export STNODEFAULTFOLDER=0
+# finds first user in the admin group
+ADMIN_USER=$(cat /etc/group | grep administrators | head -n 1 | awk -F: '{ print $4}')
 
-# start the binary
-${APKG_PATH}/syncthing/syncthing -no-browser -home=${ST_HOME} -gui-address="http://${ADDRESS}:${PORT}" 2>&1 >> $log
-
+# start the binary as ADMIN_USER
+sudo -H -u $ADMIN_USER ${APKG_PATH}/syncthing/syncthing --no-default-folder -no-browser -home=${ST_HOME} -gui-address="http://${ADDRESS}:${PORT}" 2>&1 >> $log


### PR DESCRIPTION
Sycthing developers recommends against running syncthing as root. See: https://forum.syncthing.net/t/the-meaning-of-syncthing-should-not-run-as-a-privileged-or-system-user-please-consider-using-a-normal-user-account/10034

This will cause a lot of file permission issues when used with /share. This PR will:
- Downgrade and executes synching as an admin user instead of root user
- Since the admin user is by default a member of `share` group, there wont be any file permission issues while accessing the directories/files created by synching in /share.