### PR TITLE
Update Syncthing to 1.29.6, default build to OS5

### DIFF
--- a/wdpk/syncthing/apkg.rc
+++ b/wdpk/syncthing/apkg.rc
@@ -1,5 +1,5 @@
 Package:	syncthing
-Version:	1.27.1
+Version:	1.29.5
 Packager:	TFL
 Email:
 Homepage:	https://www.syncthing.net

--- a/wdpk/syncthing/apkg.rc
+++ b/wdpk/syncthing/apkg.rc
@@ -1,5 +1,5 @@
 Package:	syncthing
-Version:	1.29.5
+Version:	1.29.6
 Packager:	TFL
 Email:
 Homepage:	https://www.syncthing.net

--- a/wdpk/syncthing/build.sh
+++ b/wdpk/syncthing/build.sh
@@ -10,7 +10,7 @@ echo "Building ${APP_NAME} version ${VERSION}"
 MODELS="WDMyCloudEX4 WDMyCloudEX2 WDMyCloudMirror WDMyCloud WDMyCloudEX4100 WDMyCloudDL4100 WDMyCloudEX2100 WDMyCloudDL2100 WDMyCloudMirrorGen2 MyCloudEX2Ultra MyCloudPR4100 MyCloudPR2100"
 
 for model in $MODELS; do
-  ../../mksapkg -E -s -m $model > /dev/null
+  ../../mksapkg-OS5 -E -s -m $model > /dev/null
 done
 
 echo "Move binaries"

--- a/wdpk/syncthing/install.sh
+++ b/wdpk/syncthing/install.sh
@@ -28,7 +28,7 @@ if [ "${PLATFORM}" = "x86_64" ]; then
 else
 	PLATFORM="arm"
 fi
-VERSION="v1.29.5"
+VERSION="v1.29.6"
 
 MAINDIR="syncthing-linux-${PLATFORM}-${VERSION}"
 PACKAGE="${MAINDIR}.tar.gz"

--- a/wdpk/syncthing/install.sh
+++ b/wdpk/syncthing/install.sh
@@ -28,7 +28,7 @@ if [ "${PLATFORM}" = "x86_64" ]; then
 else
 	PLATFORM="arm"
 fi
-VERSION="v1.27.1"
+VERSION="v1.29.5"
 
 MAINDIR="syncthing-linux-${PLATFORM}-${VERSION}"
 PACKAGE="${MAINDIR}.tar.gz"


### PR DESCRIPTION
Updates Syncthing app package to current release, corrects issue with build script.