### PR TITLE
Update start.sh script for Syncthing v2

### DIFF
--- a/wdpk/syncthing/start.sh
+++ b/wdpk/syncthing/start.sh
@@ -12,4 +12,5 @@ ADDRESS=$(sed -n '/ip/ {s/.*<ip>\(\S*\)<\/ip>/\1/p;q}' /etc/NAS_CFG/config.xml )
 ADMIN_USER=$(cat /etc/group | grep administrators | head -n 1 | awk -F: '{ print $4}')
 
 # start the binary as ADMIN_USER
+export STNODEFAULTFOLDER=1
 sudo -H -u $ADMIN_USER ${APKG_PATH}/syncthing/syncthing --no-browser --home=${ST_HOME} --gui-address="http://${ADDRESS}:${PORT}" 2>&1 >> $log

--- a/wdpk/syncthing/start.sh
+++ b/wdpk/syncthing/start.sh
@@ -12,4 +12,4 @@ ADDRESS=$(sed -n '/ip/ {s/.*<ip>\(\S*\)<\/ip>/\1/p;q}' /etc/NAS_CFG/config.xml )
 ADMIN_USER=$(cat /etc/group | grep administrators | head -n 1 | awk -F: '{ print $4}')
 
 # start the binary as ADMIN_USER
-sudo -H -u $ADMIN_USER ${APKG_PATH}/syncthing/syncthing --no-default-folder -no-browser -home=${ST_HOME} -gui-address="http://${ADDRESS}:${PORT}" 2>&1 >> $log
+sudo -H -u $ADMIN_USER ${APKG_PATH}/syncthing/syncthing --no-browser --home=${ST_HOME} --gui-address="http://${ADDRESS}:${PORT}" 2>&1 >> $log


### PR DESCRIPTION
Update start.sh script for Syncthing v2

Syncthing v2 requires command line options to use a double -- syntax.
The old, single - syntax is no longer supported, which causes the start
script to fail to start. Therefore, change the syntax to the supported
one.

Additionally, remove the no longer supported --no-default-folder option,
as the whole concept of "default folder" has been removed in Syncthing
v2.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>